### PR TITLE
Fix type cast error in DoctrineStorage.php

### DIFF
--- a/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
+++ b/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
@@ -77,7 +77,7 @@ class DoctrineStorage extends Gateway
             $statement = $query->execute();
 
             foreach ($statement->fetchAllAssociative() as $row) {
-                $map[$row['url']] = $row['id'];
+                $map[$row['url']] = (int)$row['id'];
             }
         }
 


### PR DESCRIPTION
Ibexa Adminui throws an error when defining external links. An explicit type cast solves the problem.