### PR TITLE
NGSTACK-1004 upgrade bundle to ibexa 5

### DIFF
--- a/bundle/Form/Field/FieldValueFormMapper.php
+++ b/bundle/Form/Field/FieldValueFormMapper.php
@@ -25,7 +25,7 @@ class FieldValueFormMapper extends AbstractRelationFormMapper
                         'required' => $fieldDefinition->isRequired,
                         'label' => $fieldDefinition->getName(),
                         'default_location' => $this->loadDefaultLocationForSelection(
-                            $fieldSettings['selectionRoot'],
+                            $fieldSettings['selectionRoot'] !== '' ? $fieldSettings['selectionRoot'] : null,
                             $fieldForm->getConfig()->getOption('location'),
                         ),
                         'root_default_location' => $fieldSettings['rootDefaultLocation'] ?? false,

--- a/bundle/Resources/public/admin/field.js
+++ b/bundle/Resources/public/admin/field.js
@@ -178,7 +178,12 @@
         const relationsTable = relationsWrapper.querySelector('.ibexa-table');
         const startingLocationId =
             relationsContainer.dataset.defaultLocation !== '0' ? parseInt(relationsContainer.dataset.defaultLocation, 10) : null;
-        const closeUDW = () => ReactDOM.unmountComponentAtNode(udwContainer);
+        const closeUDW = () => {
+            if (udwRoot) {
+                udwRoot.unmount();
+                udwRoot = null;
+            }
+        };
         const renderRows = (items) => {
             items.forEach((item, index) => {
                 relationsContainer.insertAdjacentHTML('beforeend', renderRow(item, index));
@@ -228,7 +233,9 @@
                           'universal_discovery_widget',
                       );
 
-            ReactDOM.render(
+            udwRoot = window.ReactDOMClient.createRoot(udwContainer);
+
+            udwRoot.render(
                 React.createElement(ibexa.modules.UniversalDiscovery, {
                     onConfirm,
                     onCancel: closeUDW,
@@ -238,7 +245,6 @@
                     multiple: isSingle ? false : selectedItemsLimit !== 1,
                     multipleItemsLimit: selectedItemsLimit > 1 ? selectedItemsLimit - selectedItems.length : selectedItemsLimit,
                 }),
-                udwContainer,
             );
         };
         const excludeDuplicatedItems = (items) => {
@@ -386,6 +392,7 @@
         };
         let selectedItems = [...fieldContainer.querySelectorAll(SELECTOR_ROW)].map((row) => parseInt(row.dataset.contentId, 10));
         let selectedItemsMap = selectedItems.reduce((total, item) => ({...total, [item]: item}), {});
+        let udwRoot = null;
 
         updateAddBtnState();
         attachRowsEventHandlers();

--- a/bundle/Templating/Twig/Extension/FieldTypeRuntime.php
+++ b/bundle/Templating/Twig/Extension/FieldTypeRuntime.php
@@ -6,12 +6,9 @@ use Ibexa\Contracts\Core\Repository\Repository;
 
 class FieldTypeRuntime
 {
-    private Repository $repository;
-
-    public function __construct(Repository $repository)
-    {
-        $this->repository = $repository;
-    }
+    public function __construct(
+        private Repository $repository,
+    ) {}
 
     public function hasLocation(int $reference): bool
     {

--- a/bundle/View/ParameterProvider.php
+++ b/bundle/View/ParameterProvider.php
@@ -13,16 +13,10 @@ use Ibexa\Core\MVC\Symfony\FieldType\View\ParameterProviderInterface;
 
 final class ParameterProvider implements ParameterProviderInterface
 {
-    private ContentService $contentService;
-    private FieldTypeService $fieldTypeService;
-
     public function __construct(
-        ContentService $contentService,
-        FieldTypeService $fieldTypeService
-    ) {
-        $this->contentService = $contentService;
-        $this->fieldTypeService = $fieldTypeService;
-    }
+        private ContentService $contentService,
+        private FieldTypeService $fieldTypeService,
+    ) {}
 
     public function getViewParameters(Field $field): array
     {

--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,16 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.3",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-pdo": "*",
         "ibexa/admin-ui": "*",
         "ibexa/content-forms": "*",
-        "ibexa/core": "^4.6"
+        "ibexa/core": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "symfony/phpunit-bridge": "^6.1"
+        "phpunit/phpunit": "^9.6"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/lib/FieldType/InternalLinkValidator.php
+++ b/lib/FieldType/InternalLinkValidator.php
@@ -15,16 +15,10 @@ use function in_array;
  */
 class InternalLinkValidator
 {
-    private Content\Handler $contentHandler;
-    private Content\Type\Handler $contentTypeHandler;
-
     public function __construct(
-        Content\Handler $contentHandler,
-        Content\Type\Handler $contentTypeHandler
-    ) {
-        $this->contentHandler = $contentHandler;
-        $this->contentTypeHandler = $contentTypeHandler;
-    }
+        private Content\Handler $contentHandler,
+        private Content\Type\Handler $contentTypeHandler,
+    ) {}
 
     public function validate(Value $value, array $allowedContentTypes = []): ?ValidationError
     {

--- a/lib/FieldType/Type.php
+++ b/lib/FieldType/Type.php
@@ -26,15 +26,15 @@ use function is_string;
 
 class Type extends FieldType
 {
-    public const SELECTION_BROWSE = 0;
-    public const SELECTION_DROPDOWN = 1;
-    public const LINK_TYPE_EXTERNAL = 'external';
-    public const LINK_TYPE_INTERNAL = 'internal';
-    public const LINK_TYPE_ALL = 'all';
-    public const TARGET_LINK = 'link';
-    public const TARGET_EMBED = 'embed';
-    public const TARGET_MODAL = 'modal';
-    public const TARGET_LINK_IN_NEW_TAB = 'link_new_tab';
+    public const int SELECTION_BROWSE = 0;
+    public const int SELECTION_DROPDOWN = 1;
+    public const string LINK_TYPE_EXTERNAL = 'external';
+    public const string LINK_TYPE_INTERNAL = 'internal';
+    public const string LINK_TYPE_ALL = 'all';
+    public const string TARGET_LINK = 'link';
+    public const string TARGET_EMBED = 'embed';
+    public const string TARGET_MODAL = 'modal';
+    public const string TARGET_LINK_IN_NEW_TAB = 'link_new_tab';
 
     protected $settingsSchema = [
         'selectionMethod' => [

--- a/lib/FieldType/Type.php
+++ b/lib/FieldType/Type.php
@@ -9,7 +9,7 @@ use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
 use Ibexa\Contracts\Core\Persistence\Content\Handler as SPIContentHandler;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
-use Ibexa\Contracts\Core\Repository\Values\Content\Relation;
+use Ibexa\Contracts\Core\Repository\Values\Content\RelationType;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\FieldType\FieldType;
@@ -357,7 +357,7 @@ class Type extends FieldType
         /** @var Value $fieldValue */
         $relations = [];
         if ($fieldValue->isTypeInternal()) {
-            $relations[Relation::FIELD] = [$fieldValue->reference];
+            $relations[RelationType::FIELD->value] = [$fieldValue->reference];
         }
 
         return $relations;

--- a/lib/FieldType/Type.php
+++ b/lib/FieldType/Type.php
@@ -87,16 +87,10 @@ class Type extends FieldType
         ],
     ];
 
-    private SPIContentHandler $handler;
-    private InternalLinkValidator $targetContentValidator;
-
     public function __construct(
-        SPIContentHandler $handler,
-        InternalLinkValidator $targetContentValidator
-    ) {
-        $this->handler = $handler;
-        $this->targetContentValidator = $targetContentValidator;
-    }
+        private SPIContentHandler $handler,
+        private InternalLinkValidator $targetContentValidator,
+    ) {}
 
     public function validateFieldSettings($fieldSettings): array
     {

--- a/lib/FieldType/UrlStorage.php
+++ b/lib/FieldType/UrlStorage.php
@@ -22,7 +22,7 @@ class UrlStorage extends GatewayBasedStorage
         $this->logger ??= new NullLogger();
     }
 
-    public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context): bool
+    public function storeFieldData(VersionInfo $versionInfo, Field $field): bool
     {
         $url = (string) $field->value->externalData;
 
@@ -45,7 +45,7 @@ class UrlStorage extends GatewayBasedStorage
         return true;
     }
 
-    public function getFieldData(VersionInfo $versionInfo, Field $field, array $context): void
+    public function getFieldData(VersionInfo $versionInfo, Field $field): void
     {
         if ($field->value->data === null) {
             return;
@@ -67,7 +67,7 @@ class UrlStorage extends GatewayBasedStorage
         $field->value->externalData = $map[$id] ?? null;
     }
 
-    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds, array $context): void
+    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds): void
     {
         foreach ($fieldIds as $fieldId) {
             $this->gateway->unlinkUrl($fieldId, $versionInfo->versionNo);
@@ -79,7 +79,5 @@ class UrlStorage extends GatewayBasedStorage
         return true;
     }
 
-    public function getIndexData(VersionInfo $versionInfo, Field $field, array $context)
-    {
-    }
+    public function getIndexData(VersionInfo $versionInfo, Field $field, array $context): void {}
 }

--- a/lib/FieldType/UrlStorage.php
+++ b/lib/FieldType/UrlStorage.php
@@ -13,15 +13,13 @@ use Psr\Log\NullLogger;
 
 class UrlStorage extends GatewayBasedStorage
 {
-    protected LoggerInterface $logger;
-
-    /** @var \Netgen\IbexaFieldTypeEnhancedLink\FieldType\ExternalLinkStorage\Gateway */
-    protected $gateway;
-
-    public function __construct(StorageGatewayInterface $gateway, ?LoggerInterface $logger = null)
-    {
+    /** @param \Netgen\IbexaFieldTypeEnhancedLink\FieldType\UrlStorage\Gateway $gateway */
+    public function __construct(
+        protected StorageGatewayInterface $gateway,
+        protected ?LoggerInterface $logger = null,
+    ) {
         parent::__construct($gateway);
-        $this->logger = $logger ?? new NullLogger();
+        $this->logger ??= new NullLogger();
     }
 
     public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context): bool

--- a/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
+++ b/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
@@ -25,7 +25,6 @@ class DoctrineStorage extends Gateway
 
     /**
      * @throws \Doctrine\DBAL\Exception
-     * @throws \Doctrine\DBAL\Driver\Exception
      */
     public function getIdUrlMap(array $ids): array
     {
@@ -53,7 +52,6 @@ class DoctrineStorage extends Gateway
 
     /**
      * @throws \Doctrine\DBAL\Exception
-     * @throws \Doctrine\DBAL\Driver\Exception
      */
     public function getUrlIdMap(array $urls): array
     {
@@ -214,7 +212,6 @@ class DoctrineStorage extends Gateway
      * @param int[] $potentiallyOrphanedUrls
      *
      * @throws \Doctrine\DBAL\Exception
-     * @throws \Doctrine\DBAL\Driver\Exception
      */
     private function deleteOrphanedUrls(array $potentiallyOrphanedUrls): void
     {

--- a/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
+++ b/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
@@ -18,12 +18,9 @@ class DoctrineStorage extends Gateway
     public const URL_TABLE = DoctrineDatabase::URL_TABLE;
     public const URL_LINK_TABLE = DoctrineDatabase::URL_LINK_TABLE;
 
-    protected Connection $connection;
-
-    public function __construct(Connection $connection)
-    {
-        $this->connection = $connection;
-    }
+    public function __construct(
+        protected Connection $connection,
+    ) {}
 
     /**
      * @throws \Doctrine\DBAL\Exception

--- a/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
+++ b/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
@@ -41,7 +41,7 @@ class DoctrineStorage extends Gateway
                 ->where('id IN (:ids)')
                 ->setParameter('ids', $ids, ArrayParameterType::INTEGER);
 
-            $statement = $query->execute();
+            $statement = $query->executeQuery();
             foreach ($statement->fetchAllAssociative() as $row) {
                 $map[$row['id']] = $row['url'];
             }
@@ -70,7 +70,7 @@ class DoctrineStorage extends Gateway
                 )
                 ->setParameter('urls', $urls, ArrayParameterType::STRING);
 
-            $statement = $query->execute();
+            $statement = $query->executeQuery();
 
             foreach ($statement->fetchAllAssociative() as $row) {
                 $map[$row['url']] = (int)$row['id'];
@@ -105,7 +105,7 @@ class DoctrineStorage extends Gateway
             ->setParameter(':url', $url)
         ;
 
-        $query->execute();
+        $query->executeStatement();
 
         return (int) $this->connection->lastInsertId(
             $this->getSequenceName(self::URL_TABLE, 'id'),
@@ -133,7 +133,7 @@ class DoctrineStorage extends Gateway
             ->setParameter(':url_id', $urlId, PDO::PARAM_INT)
         ;
 
-        $query->execute();
+        $query->executeStatement();
     }
 
     /**
@@ -161,7 +161,7 @@ class DoctrineStorage extends Gateway
             ->setParameter(':contentobject_attribute_id', $fieldId, ParameterType::INTEGER)
             ->setParameter(':contentobject_attribute_version', $versionNo, ParameterType::INTEGER);
 
-        $statement = $selectQuery->execute();
+        $statement = $selectQuery->executeQuery();
         $potentiallyOrphanedUrls = $statement->fetchFirstColumn();
 
         if (empty($potentiallyOrphanedUrls)) {
@@ -197,7 +197,7 @@ class DoctrineStorage extends Gateway
                 ->setParameter('url_ids', $excludeUrlIds, ArrayParameterType::INTEGER);
         }
 
-        $deleteQuery->execute();
+        $deleteQuery->executeStatement();
 
         $this->deleteOrphanedUrls($potentiallyOrphanedUrls);
     }
@@ -235,7 +235,7 @@ class DoctrineStorage extends Gateway
             ->setParameter('url_ids', $potentiallyOrphanedUrls, ArrayParameterType::INTEGER)
         ;
 
-        $statement = $query->execute();
+        $statement = $query->executeQuery();
         $ids = $statement->fetchFirstColumn();
 
         if (empty($ids)) {
@@ -249,6 +249,6 @@ class DoctrineStorage extends Gateway
             ->setParameter('ids', $ids, ArrayParameterType::STRING)
         ;
 
-        $deleteQuery->execute();
+        $deleteQuery->executeStatement();
     }
 }

--- a/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
+++ b/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
@@ -99,10 +99,10 @@ class DoctrineStorage extends Gateway
                     'url' => ':url',
                 ],
             )
-            ->setParameter(':created', $time, PDO::PARAM_INT)
-            ->setParameter(':modified', $time, PDO::PARAM_INT)
-            ->setParameter(':original_url_md5', md5($url))
-            ->setParameter(':url', $url)
+            ->setParameter('created', $time, PDO::PARAM_INT)
+            ->setParameter('modified', $time, PDO::PARAM_INT)
+            ->setParameter('original_url_md5', md5($url))
+            ->setParameter('url', $url)
         ;
 
         $query->executeStatement();
@@ -128,9 +128,9 @@ class DoctrineStorage extends Gateway
                     'url_id' => ':url_id',
                 ],
             )
-            ->setParameter(':contentobject_attribute_id', $fieldId, PDO::PARAM_INT)
-            ->setParameter(':contentobject_attribute_version', $versionNo, PDO::PARAM_INT)
-            ->setParameter(':url_id', $urlId, PDO::PARAM_INT)
+            ->setParameter('contentobject_attribute_id', $fieldId, PDO::PARAM_INT)
+            ->setParameter('contentobject_attribute_version', $versionNo, PDO::PARAM_INT)
+            ->setParameter('url_id', $urlId, PDO::PARAM_INT)
         ;
 
         $query->executeStatement();
@@ -158,8 +158,8 @@ class DoctrineStorage extends Gateway
                     ),
                 ),
             )
-            ->setParameter(':contentobject_attribute_id', $fieldId, ParameterType::INTEGER)
-            ->setParameter(':contentobject_attribute_version', $versionNo, ParameterType::INTEGER);
+            ->setParameter('contentobject_attribute_id', $fieldId, ParameterType::INTEGER)
+            ->setParameter('contentobject_attribute_version', $versionNo, ParameterType::INTEGER);
 
         $statement = $selectQuery->executeQuery();
         $potentiallyOrphanedUrls = $statement->fetchFirstColumn();
@@ -183,8 +183,8 @@ class DoctrineStorage extends Gateway
                     ),
                 ),
             )
-            ->setParameter(':contentobject_attribute_id', $fieldId, ParameterType::INTEGER)
-            ->setParameter(':contentobject_attribute_version', $versionNo, ParameterType::INTEGER);
+            ->setParameter('contentobject_attribute_id', $fieldId, ParameterType::INTEGER)
+            ->setParameter('contentobject_attribute_version', $versionNo, ParameterType::INTEGER);
 
         if (empty($excludeUrlIds) === false) {
             $deleteQuery

--- a/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
+++ b/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
@@ -15,8 +15,8 @@ use function time;
 
 class DoctrineStorage extends Gateway
 {
-    public const URL_TABLE = DoctrineDatabase::URL_TABLE;
-    public const URL_LINK_TABLE = DoctrineDatabase::URL_LINK_TABLE;
+    public const string URL_TABLE = DoctrineDatabase::URL_TABLE;
+    public const string URL_LINK_TABLE = DoctrineDatabase::URL_LINK_TABLE;
 
     public function __construct(
         protected Connection $connection,

--- a/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
+++ b/lib/FieldType/UrlStorage/Gateway/DoctrineStorage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netgen\IbexaFieldTypeEnhancedLink\FieldType\UrlStorage\Gateway;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Ibexa\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase;
@@ -39,7 +40,7 @@ class DoctrineStorage extends Gateway
                 )
                 ->from(self::URL_TABLE)
                 ->where('id IN (:ids)')
-                ->setParameter(':ids', $ids, Connection::PARAM_INT_ARRAY);
+                ->setParameter('ids', $ids, ArrayParameterType::INTEGER);
 
             $statement = $query->execute();
             foreach ($statement->fetchAllAssociative() as $row) {
@@ -69,7 +70,7 @@ class DoctrineStorage extends Gateway
                 ->where(
                     $query->expr()->in('url', ':urls'),
                 )
-                ->setParameter(':urls', $urls, Connection::PARAM_STR_ARRAY);
+                ->setParameter('urls', $urls, ArrayParameterType::STRING);
 
             $statement = $query->execute();
 
@@ -195,7 +196,7 @@ class DoctrineStorage extends Gateway
                         ':url_ids',
                     ),
                 )
-                ->setParameter('url_ids', $excludeUrlIds, Connection::PARAM_INT_ARRAY);
+                ->setParameter('url_ids', $excludeUrlIds, ArrayParameterType::INTEGER);
         }
 
         $deleteQuery->execute();
@@ -234,7 +235,7 @@ class DoctrineStorage extends Gateway
                 ),
             )
             ->andWhere($query->expr()->isNull('link.url_id'))
-            ->setParameter('url_ids', $potentiallyOrphanedUrls, Connection::PARAM_INT_ARRAY)
+            ->setParameter('url_ids', $potentiallyOrphanedUrls, ArrayParameterType::INTEGER)
         ;
 
         $statement = $query->execute();
@@ -248,7 +249,7 @@ class DoctrineStorage extends Gateway
         $deleteQuery
             ->delete($this->connection->quoteIdentifier(self::URL_TABLE))
             ->where($deleteQuery->expr()->in('id', ':ids'))
-            ->setParameter(':ids', $ids, Connection::PARAM_STR_ARRAY)
+            ->setParameter('ids', $ids, ArrayParameterType::STRING)
         ;
 
         $deleteQuery->execute();

--- a/lib/FieldType/Value.php
+++ b/lib/FieldType/Value.php
@@ -11,12 +11,6 @@ use function is_string;
 
 class Value extends BaseValue
 {
-    public $reference;
-    public ?string $label;
-    public string $target;
-    public ?string $suffix;
-    public ?string $relAttribute;
-
     /**
      * @noinspection MagicMethodsValidityInspection
      * @noinspection PhpMissingParentConstructorInspection
@@ -24,20 +18,14 @@ class Value extends BaseValue
      * @param ?int|?string $reference
      */
     public function __construct(
-        $reference = null,
-        ?string $label = null,
-        string $target = Type::TARGET_LINK,
-        ?string $suffix = null,
-        ?string $relAttribute = null
-    ) {
-        $this->reference = $reference;
-        $this->label = $label;
-        $this->target = $target;
-        $this->suffix = $suffix;
-        $this->relAttribute = $relAttribute;
-    }
+        public $reference = null,
+        public ?string $label = null,
+        public string $target = Type::TARGET_LINK,
+        public ?string $suffix = null,
+        public ?string $relAttribute = null,
+    ) {}
 
-    public function __toString()
+    public function __toString(): string
     {
         if (is_string($this->reference)) {
             return $this->reference;

--- a/tests/integration/Core/Repository/FieldType/EnhancedLinkIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/EnhancedLinkIntegrationTest.php
@@ -180,7 +180,7 @@ class EnhancedLinkIntegrationTest extends BaseIntegrationTest
     /**
      * @depends testLoadContentTypeField
      */
-    public function testCreateExternalContent()
+    public function testCreateExternalContent(): Content
     {
         $content = $this->createContent($this->getValidExternalCreationFieldData());
         self::assertNotNull($content->id);
@@ -223,7 +223,7 @@ class EnhancedLinkIntegrationTest extends BaseIntegrationTest
         ];
     }
 
-    public function testUpdateExternalField()
+    public function testUpdateExternalField(): Content
     {
         $updatedContent = $this->updateContent($this->getValidUpdateExternalFieldData());
         self::assertNotNull($updatedContent->id);

--- a/tests/integration/Core/Repository/FieldType/EnhancedLinkIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/EnhancedLinkIntegrationTest.php
@@ -6,7 +6,7 @@ namespace Netgen\IbexaFieldTypeEnhancedLink\Tests\Integration\Core\Repository\Fi
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
-use Ibexa\Contracts\Core\Repository\Values\Content\Relation as APIRelation;
+use Ibexa\Contracts\Core\Repository\Values\Content\RelationType as APIRelationType;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\Repository\Values\Content\Relation;
@@ -44,7 +44,7 @@ class EnhancedLinkIntegrationTest extends BaseIntegrationTestCase
             new Relation(
                 [
                     'sourceFieldDefinitionIdentifier' => 'data',
-                    'type' => APIRelation::FIELD,
+                    'type' => APIRelationType::FIELD->value,
                     'sourceContentInfo' => $content->contentInfo,
                     'destinationContentInfo' => $contentService->loadContentInfo(4),
                 ],
@@ -64,7 +64,7 @@ class EnhancedLinkIntegrationTest extends BaseIntegrationTestCase
             new Relation(
                 [
                     'sourceFieldDefinitionIdentifier' => 'data',
-                    'type' => APIRelation::FIELD,
+                    'type' => APIRelationType::FIELD->value,
                     'sourceContentInfo' => $content->contentInfo,
                     'destinationContentInfo' => $contentService->loadContentInfo(49),
                 ],

--- a/tests/integration/Core/Repository/FieldType/EnhancedLinkIntegrationTest.php
+++ b/tests/integration/Core/Repository/FieldType/EnhancedLinkIntegrationTest.php
@@ -10,7 +10,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Relation as APIRelation;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\Repository\Values\Content\Relation;
-use Ibexa\Tests\Integration\Core\Repository\FieldType\BaseIntegrationTest;
+use Ibexa\Tests\Integration\Core\Repository\FieldType\BaseIntegrationTestCase;
 use Ibexa\Tests\Integration\Core\Repository\FieldType\RelationSearchBaseIntegrationTestTrait;
 use Netgen\IbexaFieldTypeEnhancedLink\FieldType\Type;
 use Netgen\IbexaFieldTypeEnhancedLink\FieldType\Value;
@@ -23,7 +23,7 @@ use function PHPUnit\Framework\assertEquals;
  * @group integration
  * @group field-type
  */
-class EnhancedLinkIntegrationTest extends BaseIntegrationTest
+class EnhancedLinkIntegrationTest extends BaseIntegrationTestCase
 {
     use RelationSearchBaseIntegrationTestTrait;
 

--- a/tests/lib/FieldType/EnhancedLinkTypeTest.php
+++ b/tests/lib/FieldType/EnhancedLinkTypeTest.php
@@ -9,7 +9,7 @@ use Ibexa\Contracts\Core\Persistence\Content\FieldValue;
 use Ibexa\Contracts\Core\Persistence\Content\Handler as SPIContentHandler;
 use Ibexa\Contracts\Core\Persistence\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
-use Ibexa\Contracts\Core\Repository\Values\Content\Relation;
+use Ibexa\Contracts\Core\Repository\Values\Content\RelationType;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
@@ -458,7 +458,7 @@ class EnhancedLinkTypeTest extends FieldTypeTestCase
         $type = $this->createFieldTypeUnderTest();
         self::assertEquals(
             [
-                Relation::FIELD => [70],
+                RelationType::FIELD->value => [70],
             ],
             $type->getRelations($type->acceptValue(70)),
         );

--- a/tests/lib/FieldType/EnhancedLinkTypeTest.php
+++ b/tests/lib/FieldType/EnhancedLinkTypeTest.php
@@ -15,7 +15,7 @@ use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
 use Ibexa\Core\Base\Exceptions\InvalidArgumentType;
 use Ibexa\Core\Base\Exceptions\NotFoundException;
 use Ibexa\Core\FieldType\ValidationError;
-use Ibexa\Tests\Core\FieldType\FieldTypeTest;
+use Ibexa\Tests\Core\FieldType\FieldTypeTestCase;
 use Netgen\IbexaFieldTypeEnhancedLink\FieldType\InternalLinkValidator;
 use Netgen\IbexaFieldTypeEnhancedLink\FieldType\Type;
 use Netgen\IbexaFieldTypeEnhancedLink\FieldType\Value;
@@ -23,7 +23,7 @@ use Netgen\IbexaFieldTypeEnhancedLink\FieldType\Value;
 /**
  * @group type
  */
-class EnhancedLinkTypeTest extends FieldTypeTest
+class EnhancedLinkTypeTest extends FieldTypeTestCase
 {
     private const int DESTINATION_CONTENT_ID = 14;
     private const int NON_EXISTENT_CONTENT_ID = 123;

--- a/tests/lib/FieldType/EnhancedLinkTypeTest.php
+++ b/tests/lib/FieldType/EnhancedLinkTypeTest.php
@@ -25,8 +25,8 @@ use Netgen\IbexaFieldTypeEnhancedLink\FieldType\Value;
  */
 class EnhancedLinkTypeTest extends FieldTypeTest
 {
-    private const DESTINATION_CONTENT_ID = 14;
-    private const NON_EXISTENT_CONTENT_ID = 123;
+    private const int DESTINATION_CONTENT_ID = 14;
+    private const int NON_EXISTENT_CONTENT_ID = 123;
 
     private $contentHandler;
 

--- a/tests/lib/Persistence/Legacy/FieldValueConverterTest.php
+++ b/tests/lib/Persistence/Legacy/FieldValueConverterTest.php
@@ -27,7 +27,7 @@ class FieldValueConverterTest extends TestCase
         $this->converter = new FieldValueConverter();
     }
 
-    public function testToStorageFieldDefinition()
+    public function testToStorageFieldDefinition(): void
     {
         $fieldDefinition = new PersistenceFieldDefinition(
             [
@@ -87,7 +87,7 @@ class FieldValueConverterTest extends TestCase
         );
     }
 
-    public function testToFieldDefinition()
+    public function testToFieldDefinition(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $storageFieldDefinition->dataText5 =
@@ -141,7 +141,7 @@ class FieldValueConverterTest extends TestCase
         self::assertEquals($expectedFieldDefinition, $actualFieldDefinition);
     }
 
-    public function testToFieldDefinitionWithDataText5Null()
+    public function testToFieldDefinitionWithDataText5Null(): void
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $storageFieldDefinition->dataText5 = null;
@@ -196,7 +196,7 @@ class FieldValueConverterTest extends TestCase
         self::assertEquals($expectedFieldDefinition, $actualFieldDefinition);
     }
 
-    public function testToFieldDefinitionWithInvalidDataText5Format()
+    public function testToFieldDefinitionWithInvalidDataText5Format(): void
     {
         $this->expectException(\JsonException::class);
 
@@ -207,7 +207,7 @@ class FieldValueConverterTest extends TestCase
         $this->converter->toFieldDefinition($storageFieldDefinition, $fieldDefinition);
     }
 
-    public function testToFieldValue()
+    public function testToFieldValue(): void
     {
         $storageFieldValue = new StorageFieldValue();
         $storageFieldValue->dataText =
@@ -240,7 +240,7 @@ class FieldValueConverterTest extends TestCase
         self::assertEquals($expectedFieldValue, $actualFieldValue);
     }
 
-    public function testToFieldValueWithDataTextNull()
+    public function testToFieldValueWithDataTextNull(): void
     {
         $storageFieldValue = new StorageFieldValue();
         $storageFieldValue->dataText = null;
@@ -256,7 +256,7 @@ class FieldValueConverterTest extends TestCase
         self::assertEquals($expectedFieldValue, $actualFieldValue);
     }
 
-    public function testToFieldValueWithInvalidDataTextFormat()
+    public function testToFieldValueWithInvalidDataTextFormat(): void
     {
         $this->expectException(\JsonException::class);
 
@@ -267,7 +267,7 @@ class FieldValueConverterTest extends TestCase
         $this->converter->toFieldValue($storageFieldValue, $fieldValue);
     }
 
-    public function testToStorageValue()
+    public function testToStorageValue(): void
     {
         $fieldValue = new FieldValue();
         $fieldValue->data = [
@@ -300,7 +300,7 @@ class FieldValueConverterTest extends TestCase
         self::assertEquals($expectedStorageFieldValue, $actualStorageFieldValue);
     }
 
-    public function testToStorageValueWithIdNull()
+    public function testToStorageValueWithIdNull(): void
     {
         $fieldValue = new FieldValue();
         $fieldValue->data = [
@@ -323,7 +323,7 @@ class FieldValueConverterTest extends TestCase
         self::assertEquals($expectedStorageFieldValue, $actualStorageFieldValue);
     }
 
-    public function testGetIndexColumn()
+    public function testGetIndexColumn(): void
     {
         $expectedIndexColumn = 'sort_key_string';
 


### PR DESCRIPTION
Upgrade to Ibexa 5 and PHP 8.3. 
Please go through the commits, I think they are clear enough to figure out what changes have been made. I've also put comments for some comments here in order to clarify them. 

- [NGSTACK-1004 specify return types for methods in 'UrlStorage' class](https://github.com/netgen/ibexa-fieldtype-enhanced-link/commit/39784d7b6e7549ede01815499c4e9487ff148971) 
specified the return types for methods and removed the `$context` argument from them because the original methods also got the `$context` argument removed 

-  [NGSTACK-1004 fix class names that are extended by 'EnhancedLinkIntegrationTest' and 'EnhancedLinkTypeTest' tests](https://github.com/netgen/ibexa-fieldtype-enhanced-link/commit/7d5f55a2c8d808a54f6c20ce449f0b590f279e07) 
extended classes just got renamed in Ibexa 5

- [NGSTACK-1004 remove throw tag from some methods in 'DoctrineStorage' class because exception is never thrown](https://github.com/netgen/ibexa-fieldtype-enhanced-link/commit/018a360b910a44fd3e2d07469457f3337a341a98)
I get a notice in PHPStorm that `\Doctrine\DBAL\Driver\Exception` is never thrown, so I removed it from PHPDoc

- [NGSTACK-1004 remove colon char in front of parameter name in 'setParameter()' method](https://github.com/netgen/ibexa-fieldtype-enhanced-link/commit/426c88af5e3256218ce0f42079719f6da6a96afd) 
consistency + once I removed the colons, all legacy tests passed (when running `vendor/bin/phpunit -c phpunit-integration-legacy.xml` command). Before, that was not the case

- [NGSTACK-1004 turn 'selectionRoot' setting into null if it is an empty string](https://github.com/netgen/ibexa-fieldtype-enhanced-link/commit/a0af46b5744d4bf9776bf53af2ea1625d53b0ba0)
This was made because the `$fieldSettings['selectionRoot']` becomes an empty string (unintentionally probably) . By default, it is set to be a **null**, but because the _selectionRoot_ is of `RelationType` type in [`FormMapper`](https://github.com/netgen/ibexa-fieldtype-enhanced-link/blob/master/bundle/Form/FieldDefinition/FormMapper.php#L37) class, the [`RelationType`](https://github.com/ibexa/content-forms/blob/main/src/lib/Form/Type/RelationType.php#L58) class uses [`RelationTransformer::reverseTransform()`](https://github.com/ibexa/content-forms/blob/main/src/lib/Form/Transformer/RelationTransformer.php#L38) method and the null value gets transformed into an empty string. 
This was not a problem before, but now with Ibexa 5, it fails because of strictly defined types. Specifically, an exception will be thrown on the changed line in the above commit when the user goes to edit some content with `ngenhancedlink` field type. This happens because the [`loadDefaultLocationForSelection()`](https://github.com/ibexa/content-forms/blame/main/src/lib/FieldType/Mapper/AbstractRelationFormMapper.php) method now strictly requires the first argument to be `int` or `null`. 